### PR TITLE
Fix method name in synopsis

### DIFF
--- a/lib/Geo/GDAL/FFI.pm
+++ b/lib/Geo/GDAL/FFI.pm
@@ -1385,7 +1385,7 @@ This is an example of creating a vector dataset.
          }
          ]
      });
- my $f = Geo::GDAL::FFI::Feature->new($layer->Defn);
+ my $f = Geo::GDAL::FFI::Feature->new($layer->GetDefn);
  $f->SetField(name => 'a');
  my $g = Geo::GDAL::FFI::Geometry->new('Point');
  $g->SetPoint(1, 2);


### PR DESCRIPTION
The others all compile and run.  They do need ```use 5.010``` to be added to the top of the scripts, but that's not really an issue I think.