### PR TITLE
SpatialReference destroy: Guard against ref count

### DIFF
--- a/lib/Geo/GDAL/FFI/SpatialReference.pm
+++ b/lib/Geo/GDAL/FFI/SpatialReference.pm
@@ -28,7 +28,13 @@ sub new {
 
 sub DESTROY {
     my $self = shift;
-    Geo::GDAL::FFI::OSRDestroySpatialReference($$self);
+    #  OSRGetReferenceCount method not yet implemented
+    my $refcount = (Geo::GDAL::FFI::OSRReference ($$self)-1);
+    Geo::GDAL::FFI::OSRDereference ($$self);  #  immediately decrement 
+    if ($refcount == 0) {
+        #warn "Calling DESTROY method for $$self\n";
+        Geo::GDAL::FFI::OSRDestroySpatialReference($$self);
+    }
 }
 
 sub Export {


### PR DESCRIPTION
Otherwise we can get double frees if objects are shared.

Not sure if this will lead to memory leaks, but it avoids test failures in Biodiverse.  Let me know if there are better approaches.  

I also had a look at implementing the GetReferenceCount method for SpatialReference objects, but am not sure what the naming convention should be given it is not in any of the already processed header files.  
