### PR TITLE
ExecuteSQL method for Dataset.pm

### DIFF
--- a/lib/Geo/GDAL/FFI/Dataset.pm
+++ b/lib/Geo/GDAL/FFI/Dataset.pm
@@ -167,7 +167,7 @@ sub ExecuteSQL {
     
     if ($lyr && defined wantarray) {
         $Geo::GDAL::FFI::parent{$lyr} = $self;
-        return bless \$lyr, 'Geo::GDAL::FFI::Layer';
+        return bless \$lyr, 'Geo::GDAL::FFI::Layer::Filter';
     }
 
     #  This is perhaps unnecessary, but ensures
@@ -345,6 +345,22 @@ sub BuildVRT {
 }
 
 1;
+
+{
+    #  dummy class for filters from ExecuteSQL
+    package Geo::GDAL::FFI::Layer::Filter;
+    use base qw /Geo::GDAL::FFI::Layer/;
+    
+    sub DESTROY {
+        my ($self) = @_;
+        my $parent = $Geo::GDAL::FFI::parent{$$self};
+        Geo::GDAL::FFI::GDALDatasetReleaseResultSet ($$parent, $$self);
+    }
+    
+    1;
+}
+
+
 
 =pod
 

--- a/lib/Geo/GDAL/FFI/Dataset.pm
+++ b/lib/Geo/GDAL/FFI/Dataset.pm
@@ -166,9 +166,13 @@ sub ExecuteSQL {
     
     if ($lyr && defined wantarray) {
         $Geo::GDAL::FFI::parent{$lyr} = $self;
+        return bless \$lyr, 'Geo::GDAL::FFI::Layer';
     }
 
-    return $lyr;
+    #  This is perhaps unnecessary, but ensures
+    #  internal  details do not leak if spatial
+    #  index is built in non-void context.
+    return undef;
 }
 
 

--- a/lib/Geo/GDAL/FFI/Dataset.pm
+++ b/lib/Geo/GDAL/FFI/Dataset.pm
@@ -165,9 +165,14 @@ sub ExecuteSQL {
         $$self, $sql, $$filter, $dialect
     );
     
-    if ($lyr && defined wantarray) {
-        $Geo::GDAL::FFI::parent{$lyr} = $self;
-        return bless \$lyr, 'Geo::GDAL::FFI::Layer::ResultSet';
+    if ($lyr) {
+        if (defined wantarray) {
+            $Geo::GDAL::FFI::parent{$lyr} = $self;
+            return bless \$lyr, 'Geo::GDAL::FFI::Layer::ResultSet';
+        }
+        else {
+            Geo::GDAL::FFI::GDALDatasetReleaseResultSet ($lyr, $$self);            
+        }
     }
 
     #  This is perhaps unnecessary, but ensures

--- a/lib/Geo/GDAL/FFI/Dataset.pm
+++ b/lib/Geo/GDAL/FFI/Dataset.pm
@@ -156,6 +156,19 @@ sub CopyLayer {
     return bless \$l, 'Geo::GDAL::FFI::Layer';
 }
 
+
+sub ExecuteSQL {
+    my ($self, $sql, $filter, $dialect) = @_;
+        
+    my $e = Geo::GDAL::FFI::GDALDatasetExecuteSQL(
+        $$self, $sql, $filter, $dialect
+    );
+    if ($e) {
+        confess Geo::GDAL::FFI::error_msg();
+    }
+}
+
+
 ## utilities
 
 sub new_options {

--- a/lib/Geo/GDAL/FFI/Dataset.pm
+++ b/lib/Geo/GDAL/FFI/Dataset.pm
@@ -160,12 +160,15 @@ sub CopyLayer {
 sub ExecuteSQL {
     my ($self, $sql, $filter, $dialect) = @_;
         
-    my $e = Geo::GDAL::FFI::GDALDatasetExecuteSQL(
+    my $lyr = Geo::GDAL::FFI::GDALDatasetExecuteSQL(
         $$self, $sql, $filter, $dialect
     );
-    if ($e) {
-        confess Geo::GDAL::FFI::error_msg();
+    
+    if ($lyr && defined wantarray) {
+        $Geo::GDAL::FFI::parent{$lyr} = $self;
     }
+
+    return $lyr;
 }
 
 

--- a/lib/Geo/GDAL/FFI/Dataset.pm
+++ b/lib/Geo/GDAL/FFI/Dataset.pm
@@ -162,7 +162,7 @@ sub ExecuteSQL {
     my ($self, $sql, $filter, $dialect) = @_;
         
     my $lyr = Geo::GDAL::FFI::GDALDatasetExecuteSQL(
-        $$self, $sql, $filter, $dialect
+        $$self, $sql, $$filter, $dialect
     );
     
     if ($lyr && defined wantarray) {

--- a/lib/Geo/GDAL/FFI/Dataset.pm
+++ b/lib/Geo/GDAL/FFI/Dataset.pm
@@ -167,7 +167,7 @@ sub ExecuteSQL {
     
     if ($lyr && defined wantarray) {
         $Geo::GDAL::FFI::parent{$lyr} = $self;
-        return bless \$lyr, 'Geo::GDAL::FFI::Layer::Filter';
+        return bless \$lyr, 'Geo::GDAL::FFI::Layer::ResultSet';
     }
 
     #  This is perhaps unnecessary, but ensures
@@ -347,14 +347,16 @@ sub BuildVRT {
 1;
 
 {
-    #  dummy class for filters from ExecuteSQL
-    package Geo::GDAL::FFI::Layer::Filter;
+    #  dummy class for result sets from ExecuteSQL
+    #  allows specialised destroy method
+    package Geo::GDAL::FFI::Layer::ResultSet;
     use base qw /Geo::GDAL::FFI::Layer/;
     
     sub DESTROY {
         my ($self) = @_;
         my $parent = $Geo::GDAL::FFI::parent{$$self};
         Geo::GDAL::FFI::GDALDatasetReleaseResultSet ($$parent, $$self);
+        delete $Geo::GDAL::FFI::parent{$$self};
     }
     
     1;

--- a/lib/Geo/GDAL/FFI/Dataset.pm
+++ b/lib/Geo/GDAL/FFI/Dataset.pm
@@ -453,6 +453,19 @@ arguments returns the first layer.
 Copies the given layer into this dataset using the name $name and
 returns the new layer. The options hash is mostly driver specific.
 
+=head2 ExecuteSQL
+ $dataset->ExecuteSQL ($sql, $filter, $dialect);
+
+ #  build a spatial index
+ $dataset->ExecuteSQL (qq{CREATE SPATIAL INDEX ON "$some_layer_name"});
+ 
+ #  filter a data set using the SQLite dialect and a second geometry
+ my $filtered = $dataset->ExecuteSQL (
+   qq{SELECT "$fld1", "$fld2" FROM "$some_layer_name"},
+   $some_geometry,
+   'SQLite',
+ );
+ 
 =head2 Info
 
  my $info = $dataset->Info($options);

--- a/t/layer.t
+++ b/t/layer.t
@@ -130,14 +130,6 @@ is_deeply $layer->GetExtent(1), $exp_extent, 'Got correct layer extent when forc
         WKT => 'POLYGON ((4 0, 4 4, 0 4, 0 0, 4 0))',
     );
 
-    my $isvalid = $filt_poly->IsRing;
-    #say $filt_poly->ExportToJSON;
-    #  debug, but envelope method also fails
-    my $ptlist = $filt_poly->GetPoints;
-    my $env = [0,0,0,0];
-    Geo::GDAL::FFI::OGR_G_GetEnvelope ($$filt_poly, $env);
-
-    #  currently crashes when $filt_poly is passed
     my $filter2 = $ds->ExecuteSQL (
         qq{SELECT * FROM "$layer_name"},
         $filt_poly,

--- a/t/layer.t
+++ b/t/layer.t
@@ -127,13 +127,15 @@ is_deeply $layer->GetExtent(1), $exp_extent, 'Got correct layer extent when forc
     is ($feat->GetField ('int_fld'), 10, 'correct field value from selection');
 
     my $filt_poly = Geo::GDAL::FFI::Geometry->new(
-        WKT => 'POLYGON ((0 0, 0 4, 4 4, 4 0, 0 0))',
+        WKT => 'POLYGON ((4 0, 4 4, 0 4, 0 0, 4 0))',
     );
 
+    my $isvalid = $filt_poly->IsRing;
+    #say $filt_poly->ExportToJSON;
     #  debug, but envelope method also fails
-    #my $ptlist = $filt_poly->GetPoints;
-    #my $env = [0,0,0,0];
-    #Geo::GDAL::FFI::OGR_G_GetEnvelope ($filt_poly, $env);
+    my $ptlist = $filt_poly->GetPoints;
+    my $env = [0,0,0,0];
+    Geo::GDAL::FFI::OGR_G_GetEnvelope ($$filt_poly, $env);
 
     #  currently crashes when $filt_poly is passed
     my $filter2 = $ds->ExecuteSQL (

--- a/t/layer.t
+++ b/t/layer.t
@@ -68,4 +68,28 @@ my $exp_extent = [1,3,1,2];
 is_deeply $layer->GetExtent(0), $exp_extent, 'Got correct layer extent, no forcing';
 is_deeply $layer->GetExtent(1), $exp_extent, 'Got correct layer extent when forced';
 
+
+
+{
+    #  need to test more than just the spatial index creation
+    my $ds = GetDriver ('ESRI Shapefile')->Create ('/vsimem/test_sql');
+    my $layer_name = 'test_sql_layer';
+    my $layer = $ds->CreateLayer ({%$schema, Name => $layer_name});
+    
+    my $f = Geo::GDAL::FFI::Feature->new($layer->GetDefn);
+    #$f->SetField(layer => 1);
+    $f->SetGeomField([WKT => 'POLYGON ((1 1, 1 2, 3 2, 3 1, 1 1))']);
+        
+    $layer->CreateFeature($f);
+    
+    my $result = eval {
+        $ds->ExecuteSQL (qq{CREATE SPATIAL INDEX ON "$layer_name"});
+    };
+    my $e = $@;
+    #  we expect 
+    ok (!$result, 'ExecuteSQL ran spatial index');
+    ok (!$e,      'ExecuteSQL did not error');
+
+}
+
 done_testing();


### PR DESCRIPTION
Adds Geo::GDAL::Dataset::ExecuteSQL method to support filters and build spatial indexes.  

Test is cursory at this stage.  

It probably needs work, as I'm not sure if the return value is correct.  The API lists a layer should be returned in several cases, but not all.  I'll modify based on suggestions.  

Remaining work (add to as needed):
- [x] Add tests
- [ ] Ensure ReleaseResultSet is called at the right time