### PR TITLE
Add GetName method to Layer.pm

### DIFF
--- a/lib/Geo/GDAL/FFI/Layer.pm
+++ b/lib/Geo/GDAL/FFI/Layer.pm
@@ -147,6 +147,11 @@ sub GetExtent {
     confess Geo::GDAL::FFI::error_msg({OGRError => $e});
 }
 
+sub GetName {
+    my ($self) = @_;
+    return $self->GetDefn->GetName;
+}
+
 1;
 
 =pod

--- a/t/layer.t
+++ b/t/layer.t
@@ -64,6 +64,16 @@ eval {
 };
 
 
+#  GetName
+{
+    my $name = $layer->GetName;
+    is ($name, '', 'Got correct default name for anonymous layer');
+    my $test_name = 'test_name';
+    my $named_layer = GetDriver('Memory')->Create->CreateLayer({Name => $test_name});
+    $name = $named_layer->GetName;
+    is ($name, $test_name, 'Got correct name for named layer');
+}
+
 my $exp_extent = [1,3,1,2];
 is_deeply $layer->GetExtent(0), $exp_extent, 'Got correct layer extent, no forcing';
 is_deeply $layer->GetExtent(1), $exp_extent, 'Got correct layer extent when forced';


### PR DESCRIPTION
Implemented as a wrapper around the Defn object
instead of dropping down to the GDAL API call.
My understanding is that the API follows the same
process, just at the API level.