### PR TITLE
Rasterize and seg faults

### DIFF
--- a/lib/Geo/GDAL/FFI/Dataset.pm
+++ b/lib/Geo/GDAL/FFI/Dataset.pm
@@ -290,15 +290,26 @@ sub Grid {
 
 sub Rasterize {
     my ($self, $args) = @_;
-    my ($path, $dst) = destination($args->{Destination});
+    
+    my $dst = $args->{Destination};
+    confess "Destination argument should not be passed for non-void context"
+      if defined wantarray && blessed $dst;
+
     my $options = new_options(\&Geo::GDAL::FFI::GDALRasterizeOptionsNew, $args->{Options});
     set_progress($options, $args, \&Geo::GDAL::FFI::GDALRasterizeOptionsSetProgress);
+    
     my $e = 0;
-    my $result = Geo::GDAL::FFI::GDALRasterize($path, $dst, $$self, $options, \$e);
+    my $result;
+    if (blessed($dst)) {
+        Geo::GDAL::FFI::GDALRasterize(undef, $$dst, $$self, $options, \$e);
+    } else {
+        $result = Geo::GDAL::FFI::GDALRasterize($dst, undef, $$self, $options, \$e);
+    }
     Geo::GDAL::FFI::GDALRasterizeOptionsFree($options);
-    confess Geo::GDAL::FFI::error_msg() // 'Rasterize failed.' if !$result || $e != 0;
-    return if !defined wantarray;
-    return bless \$result, 'Geo::GDAL::FFI::Dataset';
+    if (defined $result) {
+        confess Geo::GDAL::FFI::error_msg() // 'Rasterize failed.' if !$result || $e != 0;
+        return bless \$result, 'Geo::GDAL::FFI::Dataset';
+    }
 }
 
 sub BuildVRT {

--- a/lib/Geo/GDAL/FFI/Dataset.pm
+++ b/lib/Geo/GDAL/FFI/Dataset.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 use Carp;
 use base 'Geo::GDAL::FFI::Object';
+use Scalar::Util qw /blessed/;
 
 our $VERSION = 0.06;
 
@@ -296,6 +297,7 @@ sub Rasterize {
     my $result = Geo::GDAL::FFI::GDALRasterize($path, $dst, $$self, $options, \$e);
     Geo::GDAL::FFI::GDALRasterizeOptionsFree($options);
     confess Geo::GDAL::FFI::error_msg() // 'Rasterize failed.' if !$result || $e != 0;
+    return if !defined wantarray;
     return bless \$result, 'Geo::GDAL::FFI::Dataset';
 }
 

--- a/t/rasterize_crash.t
+++ b/t/rasterize_crash.t
@@ -1,0 +1,63 @@
+use 5.010;
+use Geo::GDAL::FFI;
+
+use Test::More;
+
+
+local $| = 1;
+
+
+my $sr = Geo::GDAL::FFI::SpatialReference->new(EPSG => 3067);
+my $source_ds = Geo::GDAL::FFI::GetDriver('ESRI Shapefile')
+    ->Create('/vsimem/test.shp');
+my $layer = $source_ds->CreateLayer({
+        Name => 'test',
+        SpatialReference => $sr,
+        GeometryType => 'Polygon',
+        Fields => [
+        {
+            Name => 'name',
+            Type => 'String'
+        }
+        ]
+    });
+my $f = Geo::GDAL::FFI::Feature->new($layer->GetDefn);
+$f->SetField(name => 'a');
+my $g = Geo::GDAL::FFI::Geometry->new('Polygon');
+my $poly = 'POLYGON ((1 2, 2 2, 2 1, 1 1, 1 2))';
+$f->SetGeomField([WKT => $poly]);
+$layer->CreateFeature($f);
+
+
+my $x_min = 0;
+my $y_max = 2;
+my $pixel_size = 1;
+
+my $fname = '/vsimem/test_' . time() . '.tiff';
+my $target_ds = Geo::GDAL::FFI::GetDriver('GTiff')->Create($fname, 3, 2);
+my $transform = [$x_min, $pixel_size, 0, $y_max, 0, -$pixel_size];
+$target_ds->SetGeoTransform($transform);
+
+#### COMMENT OUT THIS LINE TO CRASH
+#my $target_ds2 =
+$source_ds->Rasterize({
+    Destination => $target_ds,
+    Options     => [
+        -b    => 1,
+        -burn => 1,
+        -at,
+    ],
+});
+
+
+my $band_r1 = $target_ds->GetBand;
+
+say 'Reading band data';
+my $arr_ref = $band_r1->Read;
+
+say 'Got to end';
+
+
+ok (1, 'Got to end');
+
+done_testing();


### PR DESCRIPTION
Code adapted from https://github.com/ajolma/Geo-GDAL-FFI/issues/15#issuecomment-443414101 

The main difference is that it throws an exception when called in non-void context but a Destination argument is passed.  Failing loudly is probably better than returning undef and failing later when the return arg is used.

Also add a test for this behaviour.


If this looks good then I can do the same for the other utilities:
Warp
VectorTranslate
NearBlack