### PR TITLE
Add GetParent method to Layer.pm

### DIFF
--- a/lib/Geo/GDAL/FFI.pm
+++ b/lib/Geo/GDAL/FFI.pm
@@ -56,7 +56,7 @@ our $Write = 1;
 
 our @errors;
 our %immutable;
-our %parent;
+my  %parent_ref_hash;
 
 my $instance;
 
@@ -89,6 +89,32 @@ sub error_msg {
     @errors = ();
     return $msg;
 }
+
+#  internal methods
+sub _register_parent_ref {
+    my ($gdal_handle, $parent) = @_;
+    #  ensure $gdal_handle is not blessed?
+    confess "gdal handle is undefined"
+      if !defined $gdal_handle;
+    confess "Parent ref is undefined"
+      if !$parent;
+    $parent_ref_hash{$gdal_handle} = $parent;
+}
+
+sub _deregister_parent_ref {
+    my ($gdal_handle) = @_;
+    #  we get undef vals in global cleanup
+    return if !$gdal_handle;  
+    delete $parent_ref_hash{$gdal_handle};
+}
+
+sub _get_parent_ref {
+    my ($gdal_handle) = @_;
+    warn "Attempting to access non-existent parent"
+      if !$parent_ref_hash{$gdal_handle}; 
+    return $parent_ref_hash{$gdal_handle}
+}
+
 
 our %capabilities = (
     OPEN => 1,

--- a/lib/Geo/GDAL/FFI/Band.pm
+++ b/lib/Geo/GDAL/FFI/Band.pm
@@ -9,7 +9,6 @@ our $VERSION = 0.0601;
 
 sub DESTROY {
     my $self = shift;
-    #delete $Geo::GDAL::FFI::parent{$$self};
     Geo::GDAL::FFI::_deregister_parent_ref ($$self);
 }
 

--- a/lib/Geo/GDAL/FFI/Band.pm
+++ b/lib/Geo/GDAL/FFI/Band.pm
@@ -9,7 +9,8 @@ our $VERSION = 0.0601;
 
 sub DESTROY {
     my $self = shift;
-    delete $Geo::GDAL::FFI::parent{$$self};
+    #delete $Geo::GDAL::FFI::parent{$$self};
+    Geo::GDAL::FFI::_deregister_parent_ref ($$self);
 }
 
 sub GetDataType {

--- a/lib/Geo/GDAL/FFI/Dataset.pm
+++ b/lib/Geo/GDAL/FFI/Dataset.pm
@@ -79,7 +79,6 @@ sub GetBand {
     my ($self, $i) = @_;
     $i //= 1;
     my $b = Geo::GDAL::FFI::GDALGetRasterBand($$self, $i);
-    #$Geo::GDAL::FFI::parent{$b} = $self;
     Geo::GDAL::FFI::_register_parent_ref ($b, $self);
     return bless \$b, 'Geo::GDAL::FFI::Band';
 }
@@ -97,8 +96,7 @@ sub GetLayer {
     my ($self, $i) = @_;
     $i //= 0;
     my $l = Geo::GDAL::FFI::isint($i) ? Geo::GDAL::FFI::GDALDatasetGetLayer($$self, $i) :
-        Geo::GDAL::FFI::GDALDatasetGetLayerByName($$self, $i);
-    #$Geo::GDAL::FFI::parent{$l} = $self;
+    Geo::GDAL::FFI::GDALDatasetGetLayerByName($$self, $i);
     Geo::GDAL::FFI::_register_parent_ref ($l, $self);
     return bless \$l, 'Geo::GDAL::FFI::Layer';
 }
@@ -127,7 +125,6 @@ sub CreateLayer {
     Geo::GDAL::FFI::OSRRelease($sr) if $sr;
     my $msg = Geo::GDAL::FFI::error_msg();
     confess $msg if $msg;
-    #$Geo::GDAL::FFI::parent{$l} = $self;
     Geo::GDAL::FFI::_register_parent_ref ($l, $self);
     my $layer = bless \$l, 'Geo::GDAL::FFI::Layer';
     if (exists $args->{Fields}) {
@@ -156,7 +153,6 @@ sub CopyLayer {
         my $msg = Geo::GDAL::FFI::error_msg() // "GDALDatasetCopyLayer failed.";
         confess $msg if $msg;
     }
-    #$Geo::GDAL::FFI::parent{$l} = $self;
     Geo::GDAL::FFI::_register_parent_ref ($l, $self);
     return bless \$l, 'Geo::GDAL::FFI::Layer';
 }
@@ -171,7 +167,6 @@ sub ExecuteSQL {
     
     if ($lyr) {
         if (defined wantarray) {
-            #$Geo::GDAL::FFI::parent{$lyr} = $self;
             Geo::GDAL::FFI::_register_parent_ref ($lyr, $self);
             return bless \$lyr, 'Geo::GDAL::FFI::Layer::ResultSet';
         }
@@ -364,10 +359,8 @@ sub BuildVRT {
     
     sub DESTROY {
         my ($self) = @_;
-        #my $parent = $Geo::GDAL::FFI::parent{$$self};
         my $parent = Geo::GDAL::FFI::_get_parent_ref ($$self);
         Geo::GDAL::FFI::GDALDatasetReleaseResultSet ($$parent, $$self);
-        #delete $Geo::GDAL::FFI::parent{$$self};
         Geo::GDAL::FFI::_deregister_parent_ref ($$self);
     }
     

--- a/lib/Geo/GDAL/FFI/Geometry.pm
+++ b/lib/Geo/GDAL/FFI/Geometry.pm
@@ -38,7 +38,8 @@ sub new {
 
 sub DESTROY {
     my ($self) = @_;
-    delete $Geo::GDAL::FFI::parent{$$self};
+    #delete $Geo::GDAL::FFI::parent{$$self};
+    Geo::GDAL::FFI::_deregister_parent_ref ($$self);
     if ($ref{$$self}) {
         delete $ref{$$self};
         return;
@@ -173,7 +174,8 @@ sub GetGeometryCount {
 sub GetGeometry {
     my ($self, $i) = @_;
     my $g = Geo::GDAL::FFI::OGR_G_GetGeometryRef($$self, $i);
-    $Geo::GDAL::FFI::parent{$g} = $self;
+    #$Geo::GDAL::FFI::parent{$g} = $self;
+    Geo::GDAL::FFI::_register_parent_ref ($g, $self);
     $ref{$g} = 1;
     return bless \$g, 'Geo::GDAL::FFI::Geometry';
 }

--- a/lib/Geo/GDAL/FFI/Geometry.pm
+++ b/lib/Geo/GDAL/FFI/Geometry.pm
@@ -38,7 +38,6 @@ sub new {
 
 sub DESTROY {
     my ($self) = @_;
-    #delete $Geo::GDAL::FFI::parent{$$self};
     Geo::GDAL::FFI::_deregister_parent_ref ($$self);
     if ($ref{$$self}) {
         delete $ref{$$self};
@@ -174,7 +173,6 @@ sub GetGeometryCount {
 sub GetGeometry {
     my ($self, $i) = @_;
     my $g = Geo::GDAL::FFI::OGR_G_GetGeometryRef($$self, $i);
-    #$Geo::GDAL::FFI::parent{$g} = $self;
     Geo::GDAL::FFI::_register_parent_ref ($g, $self);
     $ref{$g} = 1;
     return bless \$g, 'Geo::GDAL::FFI::Geometry';

--- a/lib/Geo/GDAL/FFI/Layer.pm
+++ b/lib/Geo/GDAL/FFI/Layer.pm
@@ -16,6 +16,11 @@ sub DESTROY {
     #say STDERR "destroy $self";
 }
 
+sub GetParentDataset {
+    my ($self) = @_;
+    return Geo::GDAL::FFI::_get_parent_ref ($$self);
+}
+
 sub GetDefn {
     my $self = shift;
     my $d = Geo::GDAL::FFI::OGR_L_GetLayerDefn($$self);

--- a/lib/Geo/GDAL/FFI/Layer.pm
+++ b/lib/Geo/GDAL/FFI/Layer.pm
@@ -11,7 +11,8 @@ sub DESTROY {
     my $self = shift;
     Geo::GDAL::FFI::OGR_L_SyncToDisk($$self);
     #say STDERR "delete parent $parent{$$self}";
-    delete $Geo::GDAL::FFI::parent{$$self};
+    #delete $Geo::GDAL::FFI::parent{$$self};
+    Geo::GDAL::FFI::_deregister_parent_ref ($$self);
     #say STDERR "destroy $self";
 }
 

--- a/lib/Geo/GDAL/FFI/Layer.pm
+++ b/lib/Geo/GDAL/FFI/Layer.pm
@@ -11,7 +11,6 @@ sub DESTROY {
     my $self = shift;
     Geo::GDAL::FFI::OGR_L_SyncToDisk($$self);
     #say STDERR "delete parent $parent{$$self}";
-    #delete $Geo::GDAL::FFI::parent{$$self};
     Geo::GDAL::FFI::_deregister_parent_ref ($$self);
     #say STDERR "destroy $self";
 }

--- a/t/layer.t
+++ b/t/layer.t
@@ -188,5 +188,14 @@ is_deeply $layer->GetExtent(1), $exp_extent, 'Got correct layer extent when forc
     
 }
 
+
+{
+    my $ds = GetDriver('Memory')->Create;
+    my $layer  = $ds->CreateLayer($schema);
+    my $parent = $layer->GetParentDataset;
+
+    is ($parent, $ds, 'got parent dataset ref');
+}
+
 done_testing();
 


### PR DESCRIPTION
Converting the tracker hash to a package lexical and abstracting its access behind subs makes it less prone to mistakes in future code.
