### PR TITLE
Cache perl dependencies under travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,15 @@ language: perl
 perl:
   - "5.10"
 
+cache:
+  directories:
+    - perl_modules
+
+
 before_install:
+  - cpanm --notest local::lib
+  - eval "$(perl -Mlocal::lib=${PWD}/perl_modules)"
+
   - ./ci/${BUILD_NAME}.sh
 #  - sudo add-apt-repository ppa:ubuntugis/ubuntugis-unstable -y
 #  - sudo apt-get update


### PR DESCRIPTION
Speeds up testing, as there is no need to rebuild Alien::gdal each time.

if we need a new Alien::gdal then the cache can be deleted and the build rerun.
