### PR TITLE
Ensure the Alien::gdal data dir is found when packed using PAR::Packer

### DIFF
--- a/lib/Geo/GDAL/FFI.pm
+++ b/lib/Geo/GDAL/FFI.pm
@@ -1282,7 +1282,13 @@ eval{$ffi->attach('GDALBuildVRT' => [qw/string int opaque[] opaque opaque int*/]
         if (opendir(my $dh, $dir)) {
             CPLSetConfigOption(GDAL_DATA => $dir);
         } else {
-            warn "GDAL data directory ($dir) doesn't exist. Maybe Alien::gdal is not installed?";
+            my $dist_data_dir = Alien::gdal->dist_dir . '/share/gdal';
+            if (-d $dist_data_dir) {
+                CPLSetConfigOption(GDAL_DATA => $dist_data_dir);
+            }
+            else {
+                warn "GDAL data directory ($dir) doesn't exist. Maybe Alien::gdal is not installed?";
+            }
         }
     }
 


### PR DESCRIPTION
The package config files are not updated when packed, so point to the location the files have come from and not to the temporary directory the data are extracted to when run as a PAR archive.

When that happens, Geo::GDAL::FFI cannot find the gcs.csv file and will not run many of the processes.  

