### PR TITLE
The Alien::gdal build handles long log lines under CI

### DIFF
--- a/ci/without-gdal-dev.sh
+++ b/ci/without-gdal-dev.sh
@@ -5,6 +5,7 @@ cpanm --notest Sort::Versions
 
 # the -v ensures the progress dots are sent to stdout
 # and avoids travis timeouts
+cpanm --installdeps --notest Alien::geos::af
 cpanm --notest -v Alien::geos::af
 cpanm --installdeps --notest Alien::gdal
 cpanm --notest -v Alien::gdal

--- a/ci/without-gdal-dev.sh
+++ b/ci/without-gdal-dev.sh
@@ -8,7 +8,7 @@ cpanm --notest Alien::Build::MM
 git clone --depth=50 --branch=master https://github.com/shawnlaffan/perl-alien-gdal.git 
 cd perl-alien-gdal
 perl Makefile.PL
-make | perl -ne 'BEGIN {$|=1; open our $log, ">", "build.log"}; print "\n" if 0 == ($. % 90); print "."; print {$log} $_;' || cat build.log
+make
 make install
 cd ..
 rm -rf perl-alien-gdal

--- a/ci/without-gdal-dev.sh
+++ b/ci/without-gdal-dev.sh
@@ -3,6 +3,9 @@
 # bug in Alien::gdal Makefile.PL requires
 cpanm --notest Sort::Versions
 
+#  SWL - this gets picked up later, but avoid throwing an error now
+cpanm --notest Alien::geos::af
+
 cpanm --installdeps --notest git://github.com/shawnlaffan/perl-alien-gdal
 cpanm --notest Alien::Build::MM
 git clone --depth=50 --branch=master https://github.com/shawnlaffan/perl-alien-gdal.git 

--- a/ci/without-gdal-dev.sh
+++ b/ci/without-gdal-dev.sh
@@ -3,8 +3,11 @@
 # bug in Alien::gdal Makefile.PL requires
 cpanm --notest Sort::Versions
 
-#  SWL - this gets picked up later, but avoid throwing an error now
-cpanm --notest Alien::geos::af
+# the -v ensures the progress dots are sent to stdout
+# and avoids travis timeouts
+cpanm --notest -v Alien::geos::af
+cpanm --installdeps --notest Alien::gdal
+cpanm --notest -v Alien::gdal
 
 #cpanm --installdeps --notest git://github.com/shawnlaffan/perl-alien-gdal
 #cpanm --notest Alien::Build::MM

--- a/ci/without-gdal-dev.sh
+++ b/ci/without-gdal-dev.sh
@@ -6,12 +6,12 @@ cpanm --notest Sort::Versions
 #  SWL - this gets picked up later, but avoid throwing an error now
 cpanm --notest Alien::geos::af
 
-cpanm --installdeps --notest git://github.com/shawnlaffan/perl-alien-gdal
-cpanm --notest Alien::Build::MM
-git clone --depth=50 --branch=master https://github.com/shawnlaffan/perl-alien-gdal.git 
-cd perl-alien-gdal
-perl Makefile.PL
-make
-make install
-cd ..
-rm -rf perl-alien-gdal
+#cpanm --installdeps --notest git://github.com/shawnlaffan/perl-alien-gdal
+#cpanm --notest Alien::Build::MM
+#git clone --depth=50 --branch=master https://github.com/shawnlaffan/perl-alien-gdal.git 
+#cd perl-alien-gdal
+#perl Makefile.PL
+#make
+#make install
+#cd ..
+#rm -rf perl-alien-gdal


### PR DESCRIPTION
Remove double handling of line aggregation so travis
sees progress and does not time out.