### PR TITLE
Import less of PDL at startup, and localise its imports

### DIFF
--- a/lib/Geo/GDAL/FFI.pm
+++ b/lib/Geo/GDAL/FFI.pm
@@ -4,7 +4,8 @@ use v5.10;
 use strict;
 use warnings;
 use Carp;
-use PDL;
+use PDL::Types ();
+use Config ();  #  needed to silence some FFI::Platypus warnings
 use FFI::Platypus;
 use FFI::Platypus::Buffer;
 require Exporter;

--- a/lib/Geo/GDAL/FFI/Band.pm
+++ b/lib/Geo/GDAL/FFI/Band.pm
@@ -217,6 +217,7 @@ sub SetColorTable {
 }
 
 sub GetPiddle {
+    require PDL::Lite;  #  minimal load
     my ($self, $xoff, $yoff, $xsize, $ysize, $xdim, $ydim, $alg) = @_;
     $xoff //= 0;
     $yoff //= 0;


### PR DESCRIPTION
PDL takes about 0.25 seconds of the startup time.
This adds up when running test suites with many files
for downstream dependencies like Biodiverse.

