### PR TITLE
Travis: Verbose install on dev version

### DIFF
--- a/ci/with-gdal-dev.sh
+++ b/ci/with-gdal-dev.sh
@@ -3,3 +3,5 @@
 sudo add-apt-repository ppa:ubuntugis/ubuntugis-unstable -y
 sudo apt-get update
 sudo apt-get install libgdal-dev
+
+cpanm --notest -v Alien::gdal


### PR DESCRIPTION
GDAL 3.0 is needed for Alien::gdal since 1.18,
so the dev version now might not be sufficient
for a system install.

Mac builds for Alien::gdal use the system install, 
so could be an option instead.  This is under 
GitHub workflows, but should also be the case for Travis.  
