### PR TITLE
Add CI configs for GitHub workflows

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,92 @@
+name: linux_default_locale
+
+on:
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
+  pull_request:
+
+env:
+  PERL_MOD_DIR: /home/runner/perl5/lib/perl5
+
+jobs:
+  perl:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      
+      - uses: shogo82148/actions-setup-perl@v1
+        with:
+          perl-version: '5.32'
+
+      - name: cmake for geos
+        run: |
+          sudo apt-get --yes install cmake
+
+      - name: Locale check
+        run: |
+          locale -a
+          echo Current locale:
+          locale
+
+      - name: perl -V
+        run: perl -V
+
+      - name: Prepare for cache
+        run: |
+          perl -V > perlversion.txt
+          echo '20220320' >> perlversion.txt
+          ls -l perlversion.txt
+
+      - name: Cache CPAN modules
+        uses: actions/cache@v1
+        with:
+          path: ~/perl5
+          key: ${{ runner.os }}-build-${{ hashFiles('perlversion.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ hashFiles('perlversion.txt') }}
+
+      - name: Install Dynamic Dependencies
+        run: |
+          which -a cpanm
+          which -a perl
+          cpanm --notest local::lib
+          echo $(perl -Mlocal::lib=${HOME}/perl5)
+          eval "$(perl -Mlocal::lib=${HOME}/perl5)"
+          cpanm --notest Alien::Build
+          cpanm --installdeps --notest Alien::sqlite
+          cpanm -v Alien::sqlite
+          cpanm --installdeps --notest Alien::libtiff
+          cpanm -v Alien::libtiff
+          cpanm --installdeps --notest Alien::geos::af
+          cpanm -v Alien::geos::af
+          cpanm --installdeps --notest Alien::proj
+          cpanm -v Alien::proj
+          cpanm --installdeps --notest Alien::gdal
+          cpanm -v Alien::gdal
+          #  some feedback to check the system
+          echo GDAL LDD
+          ldd `perl -MAlien::gdal -E'print q{}, Alien::gdal->dist_dir, q{/lib/libgdal.so}'`
+
+          
+      - name: Install Geo::GDAL::FFI deps
+        run: |
+          echo $(perl -Mlocal::lib=${HOME}/perl5)
+          eval "$(perl -Mlocal::lib=${HOME}/perl5)"
+          cpanm --installdeps Geo::GDAL::FFI
+  
+      - name: Build
+        run: |
+          echo $(perl -Mlocal::lib=${HOME}/perl5)
+          eval "$(perl -Mlocal::lib=${HOME}/perl5)"
+          #  ideally we would not need this
+          export LD_LIBRARY_PATH=`perl -MAlien::geos::af -e'print Alien::geos::af->dist_dir . "/lib"'`
+          echo GDAL LDD again
+          ldd `perl -MAlien::gdal -E'print q{}, Alien::gdal->dist_dir, q{/lib/libgdal.so}'`
+          perl Makefile.PL
+          cpanm --installdeps --notest .
+          make test

--- a/.github/workflows/linux_share_build.yml
+++ b/.github/workflows/linux_share_build.yml
@@ -1,4 +1,4 @@
-name: linux_default_locale
+name: linux_share_build
 
 on:
   push:

--- a/.github/workflows/linux_share_build.yml
+++ b/.github/workflows/linux_share_build.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Prepare for cache
         run: |
           perl -V > perlversion.txt
-          echo '20220320' >> perlversion.txt
+          echo '20220320a' >> perlversion.txt
           ls -l perlversion.txt
 
       - name: Cache CPAN modules

--- a/.github/workflows/linux_share_build.yml
+++ b/.github/workflows/linux_share_build.yml
@@ -57,6 +57,7 @@ jobs:
           cpanm --notest local::lib
           echo $(perl -Mlocal::lib=${HOME}/perl5)
           eval "$(perl -Mlocal::lib=${HOME}/perl5)"
+          cpanm --notest PDL
           cpanm --notest Alien::Build
           cpanm --installdeps --notest Alien::sqlite
           cpanm -v Alien::sqlite

--- a/.github/workflows/linux_sys_build.yml
+++ b/.github/workflows/linux_sys_build.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Prepare for cache
         run: |
           perl -V > perlversion.txt
-          echo '20220320' >> perlversion.txt
+          echo '20220320a' >> perlversion.txt
           ls -l perlversion.txt
 
       - name: Cache CPAN modules

--- a/.github/workflows/linux_sys_build.yml
+++ b/.github/workflows/linux_sys_build.yml
@@ -57,6 +57,7 @@ jobs:
           cpanm --notest local::lib
           echo $(perl -Mlocal::lib=${HOME}/perl5)
           eval "$(perl -Mlocal::lib=${HOME}/perl5)"
+          cpanm --notest PDL
           cpanm --notest Alien::Build
           cpanm --installdeps --notest Alien::sqlite
           cpanm -v Alien::sqlite

--- a/.github/workflows/linux_sys_build.yml
+++ b/.github/workflows/linux_sys_build.yml
@@ -1,0 +1,92 @@
+name: linux_sys_build
+
+on:
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
+  pull_request:
+
+env:
+  PERL_MOD_DIR: /home/runner/perl5/lib/perl5
+
+jobs:
+  perl:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      
+      - uses: shogo82148/actions-setup-perl@v1
+        with:
+          perl-version: '5.32'
+
+      - name: system libs
+        run: |
+          sudo apt-get --yes install cmake libgdal-dev
+
+      - name: Locale check
+        run: |
+          locale -a
+          echo Current locale:
+          locale
+
+      - name: perl -V
+        run: perl -V
+
+      - name: Prepare for cache
+        run: |
+          perl -V > perlversion.txt
+          echo '20220320' >> perlversion.txt
+          ls -l perlversion.txt
+
+      - name: Cache CPAN modules
+        uses: actions/cache@v1
+        with:
+          path: ~/perl5
+          key: ${{ runner.os }}-build-${{ hashFiles('perlversion.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ hashFiles('perlversion.txt') }}
+
+      - name: Install Dynamic Dependencies
+        run: |
+          which -a cpanm
+          which -a perl
+          cpanm --notest local::lib
+          echo $(perl -Mlocal::lib=${HOME}/perl5)
+          eval "$(perl -Mlocal::lib=${HOME}/perl5)"
+          cpanm --notest Alien::Build
+          cpanm --installdeps --notest Alien::sqlite
+          cpanm -v Alien::sqlite
+          cpanm --installdeps --notest Alien::libtiff
+          cpanm -v Alien::libtiff
+          cpanm --installdeps --notest Alien::geos::af
+          cpanm -v Alien::geos::af
+          cpanm --installdeps --notest Alien::proj
+          cpanm -v Alien::proj
+          cpanm --installdeps --notest Alien::gdal
+          cpanm -v Alien::gdal
+          #  some feedback to check the system
+          echo GDAL LDD
+          ldd `perl -MAlien::gdal -E'print q{}, Alien::gdal->dist_dir, q{/lib/libgdal.so}'`
+
+          
+      - name: Install Geo::GDAL::FFI deps
+        run: |
+          echo $(perl -Mlocal::lib=${HOME}/perl5)
+          eval "$(perl -Mlocal::lib=${HOME}/perl5)"
+          cpanm --installdeps Geo::GDAL::FFI
+  
+      - name: Build
+        run: |
+          echo $(perl -Mlocal::lib=${HOME}/perl5)
+          eval "$(perl -Mlocal::lib=${HOME}/perl5)"
+          #  ideally we would not need this
+          export LD_LIBRARY_PATH=`perl -MAlien::geos::af -e'print Alien::geos::af->dist_dir . "/lib"'`
+          echo GDAL LDD again
+          ldd `perl -MAlien::gdal -E'print q{}, Alien::gdal->dist_dir, q{/lib/libgdal.so}'`
+          perl Makefile.PL
+          cpanm --installdeps --notest .
+          make test

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -56,6 +56,7 @@ jobs:
 
       - name: Install Dynamic Dependencies
         run: |
+          cpanm --notest PDL
           cpanm --notest Alien::Build
           cpanm --notest Alien::Build::MM
           cpanm --notest Sort::Versions

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Prepare for cache
         run: |
           perl -V > perlversion.txt
-          echo '20220320' >> perlversion.txt
+          echo '20220320a' >> perlversion.txt
           ls -l perlversion.txt
 
       - name: Cache CPAN modules

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -61,11 +61,16 @@ jobs:
           cpanm --notest Alien::Build::MM
           cpanm --notest Sort::Versions
           cpanm --notest Alien::Build::Plugin::PkgConfig::PPWrapper
+          cpanm --notest --installdeps Alien::sqlite
+          cpanm -v Alien::sqlite
           cpanm --notest --installdeps Alien::geos::af
           cpanm -v Alien::geos::af
-          cpanm --notest Alien::libtiff
-          cpanm --notest Alien::proj
-          cpanm --notest Alien::gdal          
+          cpanm --notest --installdeps Alien::libtiff
+          cpanm -v Alien::libtiff
+          cpanm --notest --installdeps Alien::proj
+          cpanm -v Alien::proj
+          cpanm --notest --installdeps Alien::gdal
+          cpanm -v Alien::gdal
       
       - name: Install Geo::GDAL::FFI deps
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,78 @@
+name: macos
+
+on:
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
+  pull_request:
+
+env:
+  PERL5LIB: /Users/runner/perl5/lib/perl5
+  PERL_LOCAL_LIB_ROOT: /Users/runner/perl5
+  PERL_MB_OPT: --install_base /Users/runner/perl5
+  PERL_MM_OPT: INSTALL_BASE=/Users/runner/perl5
+
+jobs:
+  perl:
+
+    runs-on: macOS-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Perl
+        run: |
+          brew install perl
+          echo "{/Users/runner/perl5/bin}" >> $GITHUB_PATH
+          mkdir -p ~/bin
+          cd ~/bin
+          curl -L https://cpanmin.us/ -o cpanm
+          chmod +x cpanm
+          echo "{~/bin}" >> $GITHUB_PATH
+          which perl
+          which cpanm
+
+      - name: Install GDAL and its deps
+        run: brew install gdal
+        
+      - name: perl -V
+        run: perl -V
+
+      - name: Prepare for cache
+        run: |
+          perl -V > perlversion.txt
+          echo '20220320' >> perlversion.txt
+          ls -l perlversion.txt
+
+      - name: Cache CPAN modules
+        uses: actions/cache@v1
+        with:
+          path: ~/perl5
+          key: ${{ runner.os }}-build-${{ hashFiles('perlversion.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ hashFiles('perlversion.txt') }}
+
+      - name: Install Dynamic Dependencies
+        run: |
+          cpanm --notest Alien::Build
+          cpanm --notest Alien::Build::MM
+          cpanm --notest Sort::Versions
+          cpanm --notest Alien::Build::Plugin::PkgConfig::PPWrapper
+          cpanm --notest --installdeps Alien::geos::af
+          cpanm -v Alien::geos::af
+          cpanm --notest Alien::libtiff
+          cpanm --notest Alien::proj
+          cpanm --notest Alien::gdal          
+      
+      - name: Install Geo::GDAL::FFI deps
+        run: |
+          cpanm --installdeps Geo::GDAL::FFI
+  
+      - name: Build
+        run: |
+          perl Makefile.PL
+          cpanm --installdeps --notest .
+          make test
+          

--- a/.github/workflows/macos_share_builds.yml
+++ b/.github/workflows/macos_share_builds.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Prepare for cache
         run: |
           perl -V > perlversion.txt
-          echo '20220320' >> perlversion.txt
+          echo '20220320a' >> perlversion.txt
           ls -l perlversion.txt
 
       - name: Cache CPAN modules

--- a/.github/workflows/macos_share_builds.yml
+++ b/.github/workflows/macos_share_builds.yml
@@ -1,0 +1,81 @@
+name: macos_share_build
+
+on:
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
+  pull_request:
+
+env:
+  PERL5LIB: /Users/runner/perl5/lib/perl5
+  PERL_LOCAL_LIB_ROOT: /Users/runner/perl5
+  PERL_MB_OPT: --install_base /Users/runner/perl5
+  PERL_MM_OPT: INSTALL_BASE=/Users/runner/perl5
+
+jobs:
+  perl:
+
+    runs-on: macOS-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Perl
+        run: |
+          brew install perl
+          echo "{/Users/runner/perl5/bin}" >> $GITHUB_PATH
+          mkdir -p ~/bin
+          cd ~/bin
+          curl -L https://cpanmin.us/ -o cpanm
+          chmod +x cpanm
+          echo "{~/bin}" >> $GITHUB_PATH
+          which perl
+          which cpanm
+        
+      - name: perl -V
+        run: perl -V
+
+      - name: Prepare for cache
+        run: |
+          perl -V > perlversion.txt
+          echo '20220320' >> perlversion.txt
+          ls -l perlversion.txt
+
+      - name: Cache CPAN modules
+        uses: actions/cache@v1
+        with:
+          path: ~/perl5
+          key: ${{ runner.os }}-build-${{ hashFiles('perlversion.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ hashFiles('perlversion.txt') }}
+
+      - name: Install Dynamic Dependencies
+        run: |
+          cpanm --notest Alien::Build
+          cpanm --notest Alien::Build::MM
+          cpanm --notest Sort::Versions
+          cpanm --notest Alien::Build::Plugin::PkgConfig::PPWrapper
+          cpanm --notest --installdeps Alien::geos::af
+          cpanm --notest Alien::geos::af
+          cpanm --notest Alien::libtiff
+          cpanm --notest Alien::proj
+          cpanm --notest Alien::gdal          
+      
+      - name: Install Geo::GDAL::FFI deps
+        run: |
+          cpanm --installdeps Geo::GDAL::FFI
+  
+      - name: Build
+        run: |
+          #  bandaids
+          export DYLD_LIBRARY_PATH=`perl -MAlien::geos::af -e'print Alien::geos::af->dist_dir . "/lib"'`
+          export LD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}
+          echo Set DYLD_LIBRARY_PATH and LD_LIBRARY_PATH to ${DYLD_LIBRARY_PATH}
+          #  what does libgdal want?
+          export dylibname=`perl -MAlien::gdal -E'my @arr = grep {"libgdal"} Alien::gdal->dynamic_libs; print $arr[0]'`
+          otool -L $dylibname | grep -v System
+          perl Makefile.PL
+          cpanm --installdeps --notest .
+          make test

--- a/.github/workflows/macos_share_builds.yml
+++ b/.github/workflows/macos_share_builds.yml
@@ -53,6 +53,7 @@ jobs:
 
       - name: Install Dynamic Dependencies
         run: |
+          cpanm --notest PDL
           cpanm --notest Alien::Build
           cpanm --notest Alien::Build::MM
           cpanm --notest Sort::Versions

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -84,6 +84,7 @@ jobs:
       
       - name: Install Geo::GDAL::FFI deps
         run: |
+          cpanm --notest PDL
           cpanm --installdeps Geo::GDAL::FFI
   
       - name: Build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Prepare for CPAN cache
         run: |
           perl -V > perlversion.txt
-          echo '20220320' >> perlversion.txt
+          echo '20220320a' >> perlversion.txt
           dir perlversion.txt
 
       - name: Cache CPAN modules

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,94 @@
+name: Windows
+
+on:
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
+  pull_request:
+
+env:
+  PERL5LIB: c:\cx\lib\perl5
+  PERL_LOCAL_LIB_ROOT: c:/cx
+  PERL_MB_OPT: --install_base C:/cx
+  PERL_MM_OPT: INSTALL_BASE=C:/cx
+  #ALIEN_BUILD_PRELOAD: Fetch::Cache
+  AUTOMATED_TESTING: 1
+
+jobs:
+  perl:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Perl
+        run: |
+          choco install strawberryperl
+          echo "C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+  
+      - name: perl -V
+        run: perl -V
+        
+      - name: Prepare for CPAN cache
+        run: |
+          perl -V > perlversion.txt
+          echo '20220320' >> perlversion.txt
+          dir perlversion.txt
+
+      - name: Cache CPAN modules
+        uses: actions/cache@v1
+        with:
+          path: c:\cx
+          key: ${{ runner.os }}-build-${{ hashFiles('perlversion.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ hashFiles('perlversion.txt') }}
+
+      - name: Cache Alien downloads
+        uses: actions/cache@v1
+        with:
+          path: C:\Users\runneradmin\.alienbuild
+          key: ${{ runner.os }}-build-${{ hashFiles('aliencache.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ hashFiles('aliencache.txt') }}
+  
+
+      - name: Install dependencies Alien::MSYS
+        run: |
+          cpanm --notest Alien::MSYS
+
+      - name: Install dependencies Alien::sqlite
+        run: |
+          cpanm --notest --installdeps Alien::sqlite
+          cpanm -v Alien::sqlite
+      
+      - name: Install dependencies Alien::libtiff
+        run: |
+          cpanm -v --notest Alien::libtiff
+
+      - name: Install dependencies Alien::proj
+        run: |
+          cpanm --notest --installdeps Alien::proj
+          cpanm -v Alien::proj
+
+      - name: Install dependencies Alien::geos::af
+        run: |
+          cpanm --notest --installdeps Alien::geos::af          
+          cpanm -v Alien::geos::af
+
+      - name: Install dependencies for Alien::gdal
+        run: |
+          cpanm --notest --installdeps Alien::gdal
+          cpanm -v Alien::gdal
+      
+      - name: Install Geo::GDAL::FFI deps
+        run: |
+          cpanm --installdeps Geo::GDAL::FFI
+  
+      - name: Build
+        run: |
+          perl Makefile.PL
+          cpanm --installdeps --notest .
+          make test
+


### PR DESCRIPTION
~~The Linux system install seems to be getting libgdal-dev v2 instead of v3.  This build should be on Ubuntu 20.04 which has libgdal-dev 3.0.4 so I am not sure what is going on.~~

Edit - the minimum version supported by Alien::gdal is 3.1, so the Ubuntu default is currently too low.

The others also likely need work so treat this as draft for now. 
