### PR TITLE
Only update the data dir if GDAL<=2.3.1

### DIFF
--- a/.github/workflows/linux_share_build.yml
+++ b/.github/workflows/linux_share_build.yml
@@ -70,8 +70,8 @@ jobs:
           cpanm --installdeps --notest Alien::gdal
           cpanm -v Alien::gdal
           #  some feedback to check the system
-          echo GDAL LDD
-          ldd `perl -MAlien::gdal -E'print q{}, Alien::gdal->dist_dir, q{/lib/libgdal.so}'`
+          #echo GDAL LDD
+          #ldd `perl -MAlien::gdal -E'print q{}, Alien::gdal->dist_dir, q{/lib/libgdal.so}'`
 
           
       - name: Install Geo::GDAL::FFI deps
@@ -86,8 +86,8 @@ jobs:
           eval "$(perl -Mlocal::lib=${HOME}/perl5)"
           #  ideally we would not need this
           export LD_LIBRARY_PATH=`perl -MAlien::geos::af -e'print Alien::geos::af->dist_dir . "/lib"'`
-          echo GDAL LDD again
-          ldd `perl -MAlien::gdal -E'print q{}, Alien::gdal->dist_dir, q{/lib/libgdal.so}'`
+          #echo GDAL LDD again
+          #ldd `perl -MAlien::gdal -E'print q{}, Alien::gdal->dist_dir, q{/lib/libgdal.so}'`
           perl Makefile.PL
           cpanm --installdeps --notest .
           make test

--- a/.github/workflows/linux_share_build.yml
+++ b/.github/workflows/linux_share_build.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       
       - uses: shogo82148/actions-setup-perl@v1
         with:
@@ -43,7 +43,7 @@ jobs:
           ls -l perlversion.txt
 
       - name: Cache CPAN modules
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/perl5
           key: ${{ runner.os }}-build-${{ hashFiles('perlversion.txt') }}

--- a/.github/workflows/linux_sys_build.yml
+++ b/.github/workflows/linux_sys_build.yml
@@ -70,8 +70,8 @@ jobs:
           cpanm --installdeps --notest Alien::gdal
           cpanm -v Alien::gdal
           #  some feedback to check the system
-          echo GDAL LDD
-          ldd `perl -MAlien::gdal -E'print q{}, Alien::gdal->dist_dir, q{/lib/libgdal.so}'`
+          #echo GDAL LDD
+          #ldd `perl -MAlien::gdal -E'print q{}, Alien::gdal->dist_dir, q{/lib/libgdal.so}'`
 
           
       - name: Install Geo::GDAL::FFI deps
@@ -86,8 +86,8 @@ jobs:
           eval "$(perl -Mlocal::lib=${HOME}/perl5)"
           #  ideally we would not need this
           export LD_LIBRARY_PATH=`perl -MAlien::geos::af -e'print Alien::geos::af->dist_dir . "/lib"'`
-          echo GDAL LDD again
-          ldd `perl -MAlien::gdal -E'print q{}, Alien::gdal->dist_dir, q{/lib/libgdal.so}'`
+          #echo GDAL LDD again
+          #ldd `perl -MAlien::gdal -E'print q{}, Alien::gdal->dist_dir, q{/lib/libgdal.so}'`
           perl Makefile.PL
           cpanm --installdeps --notest .
           make test

--- a/.github/workflows/linux_sys_build.yml
+++ b/.github/workflows/linux_sys_build.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       
       - uses: shogo82148/actions-setup-perl@v1
         with:
@@ -43,7 +43,7 @@ jobs:
           ls -l perlversion.txt
 
       - name: Cache CPAN modules
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/perl5
           key: ${{ runner.os }}-build-${{ hashFiles('perlversion.txt') }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: macOS-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Perl
         run: |
@@ -47,7 +47,7 @@ jobs:
           ls -l perlversion.txt
 
       - name: Cache CPAN modules
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/perl5
           key: ${{ runner.os }}-build-${{ hashFiles('perlversion.txt') }}

--- a/.github/workflows/macos_share_builds.yml
+++ b/.github/workflows/macos_share_builds.yml
@@ -71,12 +71,12 @@ jobs:
       - name: Build
         run: |
           #  bandaids
-          export DYLD_LIBRARY_PATH=`perl -MAlien::geos::af -e'print Alien::geos::af->dist_dir . "/lib"'`
-          export LD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}
-          echo Set DYLD_LIBRARY_PATH and LD_LIBRARY_PATH to ${DYLD_LIBRARY_PATH}
+          #export DYLD_LIBRARY_PATH=`perl -MAlien::geos::af -e'print Alien::geos::af->dist_dir . "/lib"'`
+          #export LD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}
+          #echo Set DYLD_LIBRARY_PATH and LD_LIBRARY_PATH to ${DYLD_LIBRARY_PATH}
           #  what does libgdal want?
-          export dylibname=`perl -MAlien::gdal -E'my @arr = grep {"libgdal"} Alien::gdal->dynamic_libs; print $arr[0]'`
-          otool -L $dylibname | grep -v System
+          #export dylibname=`perl -MAlien::gdal -E'my @arr = grep {"libgdal"} Alien::gdal->dynamic_libs; print $arr[0]'`
+          #otool -L $dylibname | grep -v System
           perl Makefile.PL
           cpanm --installdeps --notest .
           make test

--- a/.github/workflows/macos_share_builds.yml
+++ b/.github/workflows/macos_share_builds.yml
@@ -40,11 +40,11 @@ jobs:
       - name: Prepare for cache
         run: |
           perl -V > perlversion.txt
-          echo '20220320a' >> perlversion.txt
+          echo '20221130' >> perlversion.txt
           ls -l perlversion.txt
 
       - name: Cache CPAN modules
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/perl5
           key: ${{ runner.os }}-build-${{ hashFiles('perlversion.txt') }}

--- a/.github/workflows/macos_share_builds.yml
+++ b/.github/workflows/macos_share_builds.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: macOS-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Perl
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Perl
         run: |
@@ -38,7 +38,7 @@ jobs:
           dir perlversion.txt
 
       - name: Cache CPAN modules
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: c:\cx
           key: ${{ runner.os }}-build-${{ hashFiles('perlversion.txt') }}
@@ -46,7 +46,7 @@ jobs:
             ${{ runner.os }}-build-${{ hashFiles('perlversion.txt') }}
 
       - name: Cache Alien downloads
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: C:\Users\runneradmin\.alienbuild
           key: ${{ runner.os }}-build-${{ hashFiles('aliencache.txt') }}

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -18,7 +18,8 @@ WriteMakefile(
         'FFI::Platypus' => 0,
         'FFI::Platypus::Declare' => 0,
         'Alien::gdal' => 0,
-        'PDL' => 0
+        'PDL' => 0,
+        'Sort::Versions' => 0,
     },
     TEST_REQUIRES => {
         'Test::More' => 0,

--- a/lib/Geo/GDAL/FFI.pm
+++ b/lib/Geo/GDAL/FFI.pm
@@ -63,6 +63,8 @@ our @errors;
 our %immutable;
 my  %parent_ref_hash;
 
+#say STDERR "XXX " . $ENV{LD_LIBRARY_PATH};
+#my $instance = __PACKAGE__->new;
 my $instance;
 
 sub SetErrorHandling {
@@ -1494,7 +1496,7 @@ eval{$ffi->attach('GDALMultiDimTranslate' => [qw/string opaque int uint64* opaqu
     my $pc = PkgConfig->find('gdal');
     if ($pc->errmsg) {
         my $dir = Alien::gdal->dist_dir;
-        my %options = (search_path_override => [$dir . '/lib/pkgconfig']);
+        my %options = (search_path_override => ["$dir/lib/pkgconfig", "$dir/lib64/pkgconfig"]);
         $pc = PkgConfig->find('gdal', %options);
     }
     if ($pc->errmsg) {


### PR DESCRIPTION
Updates #48 

The first commit also checks for a lib64 dir, although it is probably not needed when the second commit is in place.  

The last three commits update the CI actions and disable some debug code that is not always reliable because of lib64 dirs.  These should perhaps be squashed.  
