### PR TITLE
Removed use of now discouraged FFI::Platypus::Declare module.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,7 +1,7 @@
 Revision history for Perl extension Geo::GDAL::FFI
 
-0.11
-    -
+0.11 unreleased
+    - Removed use of to FFI::Platypus::Declare, now discouraged.
 
 0.10 July 10, 2023
      - Add dependency to FFI::Platypus::Declare

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -66,7 +66,6 @@ use Config;
     PREREQ_PM => {
         PkgConfig => 0.23026,
         FFI::Platypus => 0,
-        FFI::Platypus::Declare => 0,
         PDL => 0,
         Sort::Versions => 0,
         Alien::gdal => 0,

--- a/lib/Geo/GDAL/FFI/VSI/File.pm
+++ b/lib/Geo/GDAL/FFI/VSI/File.pm
@@ -45,7 +45,7 @@ sub Write {
     my ($self, $buf) = @_;
     my $len = do {use bytes; length($buf)};
     my $ffi = FFI::Platypus->new();
-    my $address = $ffi->cast 'string' => 'opaque', $buf;
+    my $address = $ffi->cast('string' => 'opaque', $buf);
     return Geo::GDAL::FFI::VSIFWriteL($address, 1, $len, $self->{handle});
 }
 

--- a/lib/Geo/GDAL/FFI/VSI/File.pm
+++ b/lib/Geo/GDAL/FFI/VSI/File.pm
@@ -5,7 +5,6 @@ use warnings;
 use Encode qw(decode encode);
 use Carp;
 use FFI::Platypus::Buffer;
-use FFI::Platypus::Declare;
 
 our $VERSION = 0.1100;
 
@@ -45,7 +44,8 @@ sub Read {
 sub Write {
     my ($self, $buf) = @_;
     my $len = do {use bytes; length($buf)};
-    my $address = cast 'string' => 'opaque', $buf;
+    my $ffi = FFI::Platypus->new();
+    my $address = $ffi->cast 'string' => 'opaque', $buf;
     return Geo::GDAL::FFI::VSIFWriteL($address, 1, $len, $self->{handle});
 }
 


### PR DESCRIPTION
As for [FFI::Platypus::Declare](https://metacpan.org/pod/FFI::Platypus::Declare), the use of this module (now extracted from FFI::Platypus) is officially discouraged/deprecated.