### PR TITLE
Revised parse_h.pl script to parse GDAL headers up to v3.9

### DIFF
--- a/lib/Geo/GDAL/FFI.pm
+++ b/lib/Geo/GDAL/FFI.pm
@@ -448,6 +448,9 @@ sub new {
     $ffi->type('(pointer,int,int,pointer,pointer,pointer,pointer)->int' => 'GDALTransformerFunc');
     $ffi->type('(double,int,pointer,pointer,pointer)->int' => 'GDALContourWriter');
     $ffi->type('(string,string,sint64,sint64,pointer)->void' => 'GDALQueryLoggerFunc');
+    $ffi->type('(string,pointer,pointer,int,int,pointer,pointer,pointer,pointer,pointer,pointer)->int' => 'GDALVRTProcessedDatasetFuncInit');
+    $ffi->type('(string,pointer,pointer)->void' => 'GDALVRTProcessedDatasetFuncFree');
+    $ffi->type('(string,pointer,pointer,int,int,int,pointer,size_t,int,int,pointer,pointer,size_t,int,int,pointer,double,double,double,double,pointer,string,int)->int' => 'GDALVRTProcessedDatasetFuncProcess');
 
     $ffi->ignore_not_found(1);
 


### PR DESCRIPTION
This version of the  named script is fixed to correctly manage arrays instead of pointers when required (as manually fixed in PR #68  ). It is also updated to parse GDAL 3.9 headers, including the gdal_alg.h. That header is commented out in the script, which allows it to generate exactly the same code currently embedded in the master (for GDAL 3.7). I added some additional callback types, too.